### PR TITLE
libvirt-python: update to 9.7.0

### DIFF
--- a/abi_symbols
+++ b/abi_symbols
@@ -232,6 +232,7 @@ libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkDefineXMLFlags
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkDestroy
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkFree
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkGetBridgeName
+libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkGetMetadata
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkGetName
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkGetXMLDesc
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkIsActive
@@ -247,6 +248,7 @@ libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkPortPtrWrap
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkPort_pointer
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkPtrWrap
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkSetAutostart
+libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkSetMetadata
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkUndefine
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetworkUpdate
 libvirtmod.cpython-310-x86_64-linux-gnu.so:libvirt_virNetwork_pointer

--- a/abi_used_symbols
+++ b/abi_used_symbols
@@ -420,6 +420,7 @@ libvirt.so.0:virNetworkFree
 libvirt.so.0:virNetworkGetAutostart
 libvirt.so.0:virNetworkGetBridgeName
 libvirt.so.0:virNetworkGetDHCPLeases
+libvirt.so.0:virNetworkGetMetadata
 libvirt.so.0:virNetworkGetName
 libvirt.so.0:virNetworkGetUUID
 libvirt.so.0:virNetworkGetUUIDString
@@ -442,6 +443,7 @@ libvirt.so.0:virNetworkPortLookupByUUIDString
 libvirt.so.0:virNetworkPortSetParameters
 libvirt.so.0:virNetworkRef
 libvirt.so.0:virNetworkSetAutostart
+libvirt.so.0:virNetworkSetMetadata
 libvirt.so.0:virNetworkUndefine
 libvirt.so.0:virNetworkUpdate
 libvirt.so.0:virNodeAllocPages

--- a/package.yml
+++ b/package.yml
@@ -1,8 +1,8 @@
 name       : libvirt-python
-version    : 9.5.0
-release    : 40
+version    : 9.7.0
+release    : 41
 source     :
-    - https://libvirt.org/sources/python/libvirt-python-9.5.0.tar.gz : 8b6ace0810528ec020e121bf1a142c12f786b12c130c7899e9397f0f3a82c392
+    - https://libvirt.org/sources/python/libvirt-python-9.7.0.tar.gz : d8be9eaa75bad75641e13b608285926cde46d6440a239f106277a6dd55235470
 license    : LGPL-2.1-or-later
 homepage   : https://libvirt.org/
 component  : programming.python

--- a/pspec_x86_64.xml
+++ b/pspec_x86_64.xml
@@ -26,10 +26,10 @@
             <Path fileType="library">/usr/lib/python3.10/site-packages/__pycache__/libvirtaio.cpython-310.pyc</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_lxc.py</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_python-9.5.0-py3.10.egg-info/PKG-INFO</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_python-9.5.0-py3.10.egg-info/SOURCES.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_python-9.5.0-py3.10.egg-info/dependency_links.txt</Path>
-            <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_python-9.5.0-py3.10.egg-info/top_level.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_python-9.7.0-py3.10.egg-info/PKG-INFO</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_python-9.7.0-py3.10.egg-info/SOURCES.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_python-9.7.0-py3.10.egg-info/dependency_links.txt</Path>
+            <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_python-9.7.0-py3.10.egg-info/top_level.txt</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/libvirt_qemu.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/libvirtaio.py</Path>
             <Path fileType="library">/usr/lib/python3.10/site-packages/libvirtmod.cpython-310-x86_64-linux-gnu.so</Path>
@@ -38,9 +38,9 @@
         </Files>
     </Package>
     <History>
-        <Update release="40">
-            <Date>2023-07-12</Date>
-            <Version>9.5.0</Version>
+        <Update release="41">
+            <Date>2023-09-17</Date>
+            <Version>9.7.0</Version>
             <Comment>Packaging update</Comment>
             <Name>Thomas Staudinger</Name>
             <Email>Staudi.Kaos@gmail.com</Email>


### PR DESCRIPTION
No code changes since 9.5.0

Depends on https://github.com/solus-packages/libvirt/pull/1

**Test Plan:**
- Created several VMs using `virt-manager`

### Checklist

- [x] Package was built and tested against unstable
